### PR TITLE
make the API Key private

### DIFF
--- a/src/Forge.php
+++ b/src/Forge.php
@@ -25,7 +25,7 @@ class Forge
      *
      * @var string
      */
-    public $apiKey;
+    private $apiKey;
 
     /**
      * The Guzzle HTTP Client instance.


### PR DESCRIPTION
as a public property it is showing up in the resources we return. I feel like we should protect this key a little more and keep it hidden.

users should not set the `apiKey` property directly, either, but should be forced to use the `setApiKey()` method.