### PR TITLE
do not set guzzle manually in the constructor

### DIFF
--- a/src/Forge.php
+++ b/src/Forge.php
@@ -53,10 +53,6 @@ class Forge
         if (! is_null($apiKey)) {
             $this->setApiKey($apiKey, $guzzle);
         }
-
-        if (! is_null($guzzle)) {
-            $this->guzzle = $guzzle;
-        }
     }
 
     /**


### PR DESCRIPTION
this same logic is already handled in the `setApiKey()` method, so we don't need to run it twice.