### PR TITLE
Fix ErrorException fetching backup configuration

### DIFF
--- a/src/Resources/BackupConfiguration.php
+++ b/src/Resources/BackupConfiguration.php
@@ -87,7 +87,7 @@ class BackupConfiguration extends Resource
         );
 
         $this->backups = $this->transformCollection(
-            $this->backups,
+            $this->backups ?: [],
             Backup::class,
             ['server_id' => $this->serverId]
         );


### PR DESCRIPTION
After fresh created backup configuration backups are empty.
If backup configuration has no backups it throws error.
Fixes #72