### PR TITLE
phpReboot() fix to include PHP version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,7 @@ $forge->enableOPCache($serverId);
 $forge->disableOPCache($serverId);
 
 // PHP
+$forge->rebootPHP($serverId, $version);
 $forge->upgradePHP($serverId);
 ```
 

--- a/src/Actions/ManagesServers.php
+++ b/src/Actions/ManagesServers.php
@@ -194,11 +194,12 @@ trait ManagesServers
      * Reboot PHP on the server.
      *
      * @param  string $serverId
+     * @param  array $data
      * @return void
      */
-    public function rebootPHP($serverId)
+    public function rebootPHP($serverId, array $data)
     {
-        $this->post("servers/$serverId/php/reboot");
+        $this->post("servers/$serverId/php/reboot", $data);
     }
 
     /**

--- a/src/Resources/Server.php
+++ b/src/Resources/Server.php
@@ -249,9 +249,9 @@ class Server extends Resource
      *
      * @return void
      */
-    public function rebootPHP()
+    public function rebootPHP(array $data)
     {
-        return $this->forge->rebootPHP($this->id);
+        return $this->forge->rebootPHP($this->id, $data);
     }
 
     /**


### PR DESCRIPTION
PHP version added to rebootPHP() method.

Fixes #74