### PR TITLE
Add Security Rules to SDK

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -299,6 +299,21 @@ $worker->delete();
 $worker->restart($wait = true);
 ```
 
+## Security Rules
+
+```php
+$forge->securityRules($serverId, $siteId);
+$forge->securityRule($serverId, $siteId, $ruleId);
+$forge->createSecurityRule($serverId, $siteId, array $data);
+$forge->deleteSecurityRule($serverId, $siteId, $ruleId);
+```
+
+On a SecurityRule Instance you may also call:
+
+```php
+$securityRule->delete();
+```
+
 ## Site Webhooks
 
 ```php

--- a/src/Actions/ManagesSecurityRules.php
+++ b/src/Actions/ManagesSecurityRules.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Themsaid\Forge\Actions;
+
+use Themsaid\Forge\Resources\SecurityRule;
+
+trait ManagesSecurityRules
+{
+    /**
+     * Get the collection of security rules.
+     *
+     * @param  integer $serverId
+     * @param  integer $siteId
+     * @return SecurityRule[]
+     */
+    public function securityRules($serverId, $siteId)
+    {
+        return $this->transformCollection(
+            $this->get("servers/$serverId/sites/$siteId/security-rules")['security_rules'],
+            SecurityRule::class,
+            ['server_id' => $serverId, 'site_id' => $siteId]
+        );
+    }
+
+    /**
+     * Get a security rule instance.
+     *
+     * @param  integer $serverId
+     * @param  integer $siteId
+     * @param  integer $ruleId
+     * @return SecurityRule
+     */
+    public function securityRule($serverId, $siteId, $ruleId)
+    {
+        return new SecurityRule(
+            $this->get("servers/$serverId/sites/$siteId/security-rules/$ruleId")['security_rule']
+            + ['server_id' => $serverId, 'site_id' => $siteId], $this
+        );
+    }
+
+    /**
+     * Create a new security rule.
+     *
+     * @param  integer $serverId
+     * @param  integer $siteId
+     * @param  array $data
+     * @param  boolean $wait
+     * @return SecurityRule
+     */
+    public function createSecurityRule($serverId, $siteId, array $data, $wait = true)
+    {
+        $securityRule = $this->post("servers/$serverId/sites/$siteId/security-rules", $data)['security_rule'];
+
+        if ($wait) {
+            return $this->retry($this->getTimeout(), function () use ($serverId, $siteId, $securityRule) {
+                $securityRule = $this->securityRule($serverId, $siteId, $securityRule['id']);
+
+                return $securityRule->status == 'installed' ? $securityRule : null;
+            });
+        }
+
+        return new SecurityRule($securityRule + ['server_id' => $serverId, 'site_id' => $siteId], $this);
+    }
+
+    /**
+     * Delete the given security rule.
+     *
+     * @param  integer $serverId
+     * @param  integer $siteId
+     * @param  integer $ruleId
+     * @return void
+     */
+    public function deleteSecurityRule($serverId, $siteId, $ruleId)
+    {
+        $this->delete("servers/$serverId/sites/$siteId/security-rules/$ruleId");
+    }
+}

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -22,6 +22,7 @@ class Forge
         Actions\ManagesCertificates,
         Actions\ManagesFirewallRules,
         Actions\ManagesRedirectRules,
+        Actions\ManagesSecurityRules,
         Actions\ManagesMysqlDatabases,
         Actions\ManagesMonitors;
 

--- a/src/Resources/SecurityRule.php
+++ b/src/Resources/SecurityRule.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Themsaid\Forge\Resources;
+
+class SecurityRule extends Resource
+{
+    /**
+     * The id of the rule.
+     *
+     * @var integer
+     */
+    public $id;
+
+    /**
+     * The id of the server.
+     *
+     * @var integer
+     */
+    public $serverId;
+
+    /**
+     * The id of the site.
+     *
+     * @var integer
+     */
+    public $siteId;
+
+    /**
+     * The name of the rule.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The path to route of the rule.
+     *
+     * @var string
+     */
+    public $path;
+
+    /**
+     * The credentials of the redirect rule.
+     *
+     * @var string
+     */
+    public $credentials;
+
+    /**
+     * The date/time the rule was created.
+     *
+     * @var string
+     */
+    public $createdAt;
+
+
+
+    /**
+     * Delete the given redirect rule.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->forge->deleteSecurityRule($this->serverId, $this->siteId, $this->id);
+    }
+}


### PR DESCRIPTION
This PR adds the new Security Rules [https://forge.laravel.com/api-documentation#security-rules] to the SDK. Documentation is included.