### PR TITLE
[3.x] Helper classes for known values

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ On multiple actions supported by this SDK you may need to pass some parameters, 
 
 ```php
 $server = $forge->createServer([
-    "provider"=> "ocean2",
+    "provider"=> ServerProviders::DIGITAL_OCEAN,
     "credential_id"=> 1,
     "name"=> "test-via-api",
     "size"=> "01",
     "database"=> "test123",
-    "php_version"=> "php71",
+    "database_type" => InstallableServices::POSTGRES,
+    "php_version"=> InstallableServices::PHP_71,
     "region"=> "ams2"
 ]);
 ```

--- a/src/GitProviders.php
+++ b/src/GitProviders.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Forge;
+
+abstract class GitProviders
+{
+    const BITBUCKET = 'bitbucket';
+    const CUSTOM = 'custom';
+    const GITHUB = 'github';
+    const GITLAB = 'gitlab';
+}

--- a/src/InstallableServices.php
+++ b/src/InstallableServices.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Forge;
+
+abstract class InstallableServices
+{
+    const PHP_56 = 'php56';
+    const PHP_70 = 'php70';
+    const PHP_71 = 'php71';
+    const PHP_72 = 'php72';
+    const PHP_73 = 'php73';
+    const PHP_74 = 'php74';
+
+    const MYSQL = 'mysql';
+    const MYSQL_8 = 'mysql8';
+
+    const MARIADB = 'mariadb';
+
+    const POSTGRES = 'postgres';
+}

--- a/src/LoadBalancingStrategies.php
+++ b/src/LoadBalancingStrategies.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Forge;
+
+abstract class LoadBalancingStrategies
+{
+    const ROUND_ROBIN = 'round_robin';
+    const LEAST_CONNECTIONS = 'least_conn';
+    const IP_HASH = 'ip_hash';
+}

--- a/src/ServerProviders.php
+++ b/src/ServerProviders.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Forge;
+
+abstract class ServerProviders
+{
+    const AWS = 'aws';
+    const CUSTOM = 'custom';
+    const DIGITAL_OCEAN = 'ocean2';
+    const HETZNER = 'hetzner';
+    const LINODE = 'linode';
+    const VULTR = 'vultr';
+}


### PR DESCRIPTION
This PR (based on #46) adds helper classes for known values when performing operations with Server in Laravel Forge, the main purpose of these classes is to provide a better and more user-friendly way of specifying server requirements.

There is no contributing file so please guide me through the required changes if needed, I will be more than happy to adjust the code to fit your specifications.

The additions are:
- ServerProviders: VPS providers that are supported by Laravel Forge.
- GitProviders: Git PaaS supported by Laravel Forge.
- InstallableServices: Software which versions/type can be specified when provisioning a new server (ex. PHP version to be used).

I didn't add any tests as all classes are holding constants only. 😄

Thanks for looking at my PR 🖖 

p.s. I went with the default but let me know if I should point my PR to the v2 tag.