### PR TITLE
Adds resetDeploymentState() and siteDeploymentLog() to Site resource

### DIFF
--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -244,6 +244,26 @@ class Site extends Resource
     }
 
     /**
+     * Reset deployment status for a given site
+     *
+     * @return void
+     */
+    public function resetDeploymentState()
+    {
+        return $this->forge->resetDeploymentState($this->serverId, $this->id);
+    }
+
+    /**
+     * Get the last deployment log of the site.
+     *
+     * @return string
+     */
+    public function siteDeploymentLog()
+    {
+        return $this->forge->siteDeploymentLog($this->serverId, $this->id);
+    }
+
+    /**
      * Enable Hipchat Notifications for the given site.
      *
      * @param  array  $data


### PR DESCRIPTION
Currently the Site resources doesn't have methods for resetDeploymentState() and siteDeploymentLog(), which are found in the ManagesSites trait.  This would prevent calling the methods against a Site object.

```php
$site = $forge->site(329730,888419);
$log = $site->siteDeploymentLog();
$site->resetDeploymentState();
```

This PR adds these methods.