### PR TITLE
Improve assertions

### DIFF
--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -80,7 +80,7 @@ class ForgeSDKTest extends TestCase
         try {
             $forge->recipes();
         } catch (FailedActionException $e) {
-            $this->assertEquals('Error!', $e->getMessage());
+            $this->assertSame('Error!', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.