### PR TITLE
[3.x] Nginx Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The [Laravel Forge](https://forge.laravel.com) SDK provides an expressive interf
     - [Security Rules](#security-rules)
     - [Site Webhooks](#site-webhooks)
     - [Site SSL Certificates](#site-ssl-certificates)
+    - [Nginx Templates](#nginx-templates)
     - [Managing Databases](#managing-databases)
     - [Managing Recipes](#managing-recipes)
     - [Managing Backups](#backups)
@@ -392,6 +393,23 @@ $certificate->delete();
 $certificate->getSigningRequest();
 $certificate->install($wait = true);
 $certificate->activate($wait = true);
+```
+### Nginx Templates
+
+```php
+$forge->nginxTemplates($serverId);
+$forge->nginxDefaultTemplate($serverId);
+$forge->nginxTemplate($serverId, $templateId);
+$forge->createNginxTemplate($serverId, array $data);
+$forge->updateNginxTemplate($serverId, $templateId, array $data);
+$forge->deleteNginxTemplate($serverId, $templateId);
+```
+
+On a `NginxTemplate` instance you may also call:
+
+```php
+$nginxTemplate->update(array $data);
+$nginxTemplate->delete();
 ```
 
 ### Managing Databases

--- a/src/Actions/ManagesNginxTemplates.php
+++ b/src/Actions/ManagesNginxTemplates.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Laravel\Forge\Actions;
+
+use Laravel\Forge\Resources\NginxTemplate;
+
+trait ManagesNginxTemplates
+{
+    /**
+     * Get the collection of Nginx Templates.
+     *
+     * @param  int  $serverId
+     * @return \Laravel\Forge\Resources\NginxTemplate[]
+     */
+    public function nginxTemplates($serverId)
+    {
+        return $this->transformCollection(
+            $this->get("servers/$serverId/nginx/templates")['templates'],
+            NginxTemplate::class
+        );
+    }
+
+    /**
+     * Get a Nginx Template instance.
+     *
+     * @param  int  $serverId
+     * @param  int  $templateId
+     * @return \Laravel\Forge\Resources\NginxTemplate
+     */
+    public function nginxTemplate($serverId, $templateId)
+    {
+        return new NginxTemplate(
+            $this->get("servers/$serverId/nginx/templates/$templateId")['template'], $this
+        );
+    }
+
+    /**
+     * Get a Nginx Default Template instance.
+     *
+     * @param  int  $serverId
+     * @return \Laravel\Forge\Resources\NginxTemplate
+     */
+    public function nginxDefaultTemplate($serverId)
+    {
+        return new NginxTemplate(
+            $this->get("servers/$serverId/nginx/templates/default"), $this
+        );
+    }
+
+    /**
+     * Create a new Nginx Template.
+     *
+     * @param  int  $serverId
+     * @param  array  $data
+     * @param  bool  $wait
+     * @return \Laravel\Forge\Resources\NginxTemplate
+     */
+    public function createNginxTemplate($serverId, array $data, $wait = true)
+    {
+        $template = $this->post("servers/$serverId/nginx/templates", $data)['template'];
+
+        if ($wait) {
+            return $this->retry($this->getTimeout(), function () use ($serverId, $template) {
+                return $this->nginxTemplate($serverId, $template['id']);
+            });
+        }
+
+        return new NginxTemplate($template, $this);
+    }
+
+    /**
+     * Update the given Nginx Template.
+     *
+     * @param  int  $serverId
+     * @param  int  $templateId
+     * @param  array  $data
+     * @return \Laravel\Forge\Resources\NginxTemplate
+     */
+    public function updateNginxTemplate($serverId, $templateId, array $data)
+    {
+        return new NginxTemplate(
+            $this->put("servers/$serverId/nginx/templates/$templateId", $data)['template'], $this
+        );
+    }
+
+    /**
+     * Delete the given Nginx Template.
+     *
+     * @param  int  $serverId
+     * @param  int  $templateId
+     * @return void
+     */
+    public function deleteNginxTemplate($serverId, $templateId)
+    {
+        $this->delete("servers/$serverId/nginx/templates/$templateId");
+    }
+}

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -24,7 +24,8 @@ class Forge
         Actions\ManagesRedirectRules,
         Actions\ManagesSecurityRules,
         Actions\ManagesDatabases,
-        Actions\ManagesMonitors;
+        Actions\ManagesMonitors,
+        Actions\ManagesNginxTemplates;
 
     /**
      * The Forge API Key.

--- a/src/Resources/NginxTemplate.php
+++ b/src/Resources/NginxTemplate.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\Forge\Resources;
+
+class NginxTemplate extends Resource
+{
+    /**
+     * The id of the nginx template.
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * The id of the server.
+     *
+     * @var int
+     */
+    public $serverId;
+
+    /**
+     * The name of the nginx template.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * Update the given nginx template.
+     *
+     * @param  array  $data
+     * @return \Laravel\Forge\Resources\NginxTemplate
+     */
+    public function update(array $data)
+    {
+        return $this->forge->updateNginxTemplate($this->serverId, $this->id, $data);
+    }
+
+    /**
+     * Delete the given nginx template.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->forge->deleteNginxTemplate($this->serverId, $this->id);
+    }
+}

--- a/src/Resources/NginxTemplate.php
+++ b/src/Resources/NginxTemplate.php
@@ -26,6 +26,13 @@ class NginxTemplate extends Resource
     public $name;
 
     /**
+     * The content of the nginx template.
+     *
+     * @var string
+     */
+    public $content;
+
+    /**
      * Update the given nginx template.
      *
      * @param  array  $data


### PR DESCRIPTION
This PR adds Nginx Templates to the SDK [https://forge.laravel.com/api-documentation#nginx-templates](https://forge.laravel.com/api-documentation#nginx-templates).
Deletion of template in not yet working which caused by unsupported Forge API `DELETE` method.

Documentation is also updated.

