### PR TITLE
[3.x] Add change site PHP version methods to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ $site->installWordPress($data);
 $site->removeWordPress();
 $site->installPhpMyAdmin($data);
 $site->removePhpMyAdmin();
+$site->changePHPVersion($version);
 ```
 
 ### Site Workers

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ $forge->deploySite($serverId, $siteId, $wait = false);
 $forge->resetDeploymentState($serverId, $siteId);
 $forge->siteDeploymentLog($serverId, $siteId);
 
+// PHP Version
+$forge->changeSitePHPVersion($serverId, $siteId, $version);
+
 // Notifications
 $forge->enableHipchatNotifications($serverId, $siteId, array $data);
 $forge->disableHipchatNotifications($serverId, $siteId);

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -392,6 +392,19 @@ trait ManagesSites
     }
 
     /**
+     * Change the given site's PHP version.
+     *
+     * @param  int  $serverId
+     * @param  int  $siteId
+     * @param  string  $version
+     * @return void
+     */
+    public function changeSitePHPVersion($serverId, $siteId, $version)
+    {
+        $this->put("servers/$serverId/sites/$siteId/php", ['version' => $version]);
+    }
+
+    /**
      * Update the given site's balanced nodes.
      *
      * @param  int  $serverId

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -325,4 +325,15 @@ class Site extends Resource
     {
         $this->forge->removePhpMyAdmin($this->serverId, $this->id);
     }
+
+    /**
+     * Change the site's PHP version.
+     *
+     * @param  string  $version
+     * @return void
+     */
+    public function changePHPVersion($version)
+    {
+        $this->forge->changeSitePHPVersion($this->serverId, $this->id, $version);
+    }
 }


### PR DESCRIPTION
This PR adds methods on both Forge and Resources\Site classes to change site PHP version, as documented on the [API documentation](https://forge.laravel.com/api-documentation#change-site-php-version)