### PR TITLE
Add support for site and server tags in respective resources

### DIFF
--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -82,4 +82,18 @@ class Resource
             return new $class($data + $extraData, $this->forge);
         }, $collection);
     }
+
+    /**
+     * Transform the collection of tags to a string.
+     *
+     * @param  array  $tags
+     * @param  string|null  $separator
+     * @return string
+     */
+    protected function transformTags(array $tags, $separator = null)
+    {
+        $separator = $separator ?: ', ';
+
+        return implode($separator, array_column($tags ?? [], 'name'));
+    }
 }

--- a/src/Resources/Server.php
+++ b/src/Resources/Server.php
@@ -131,6 +131,13 @@ class Server extends Resource
     public $provisionCommand;
 
     /**
+     * The tags associated with the server.
+     *
+     * @var array
+     */
+    public $tags = [];
+
+    /**
      * Update the given server.
      *
      * @param  array  $data
@@ -354,5 +361,16 @@ class Server extends Resource
     public function updatePHP($version)
     {
         $this->forge->updatePHP($this->id, $version);
+    }
+
+    /**
+     * Return the tags associated with the server.
+     *
+     * @param  string|null  $separator
+     * @return string
+     */
+    public function tags($separator = null)
+    {
+        return $this->transformTags($this->tags, $separator);
     }
 }

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -399,4 +399,15 @@ class Site extends Resource
     {
         $this->forge->changeSitePHPVersion($this->serverId, $this->id, $version);
     }
+
+    /**
+     * Return the aliases associated with the site.
+     *
+     * @param  string|null  $separator
+     * @return string
+     */
+    public function tags($separator = null)
+    {
+        return $this->transformTags($this->tags, $separator);
+    }
 }


### PR DESCRIPTION
This PR adds the missing `tags` property to the `Server` resource, as well as exposing methods on the `Server` and `Site` resources to return the tags as a comma-separated list.

I'll submit a related PR on the laravel/forge-cli repo that utilises these new methods as well.

I've opted for a default of an spaced list, and override that on the `ServerCurrentCommand` as the `successfulStep` method in the Forge CLI will otherwise transform the tags using `ucwords`.