### PR TITLE
[3.x] Add deployment history

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ $forge->disableQuickDeploy($serverId, $siteId);
 $forge->deploySite($serverId, $siteId, $wait = false);
 $forge->resetDeploymentState($serverId, $siteId);
 $forge->siteDeploymentLog($serverId, $siteId);
+$forge->deploymentHistory($serverId, $siteId);
+$forge->deploymentHistoryDeployment($serverId, $siteId, $deploymentId);
+$forge->deploymentHistoryOutput($serverId, $siteId, $deploymentId);
 
 // PHP Version
 $forge->changeSitePHPVersion($serverId, $siteId, $version);
@@ -292,6 +295,9 @@ $site->disableQuickDeploy();
 $site->deploySite($wait = false);
 $site->resetDeploymentState();
 $site->siteDeploymentLog();
+$site->getDeploymentHistory();
+$site->getDeploymentHistoryDeployment($deploymentId);
+$site->getDeploymentHistoryOutput($deploymentId);
 $site->installWordPress($data);
 $site->removeWordPress();
 $site->installPhpMyAdmin($data);

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -340,7 +340,7 @@ trait ManagesSites
     {
         return $this->get("/api/v1/servers/$serverId/sites/$siteId/deployment-history/$deploymentId");
     }
-    
+
     /**
      * Get the output for a deployment of the site.
      *

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -317,7 +317,7 @@ trait ManagesSites
     }
 
     /**
-     * Get the deployments history of the site.
+     * Get the deployment history of the site.
      *
      * @param  int  $serverId
      * @param  int  $siteId
@@ -329,7 +329,7 @@ trait ManagesSites
     }
 
     /**
-     * Get a single deployment from deployment history of the site.
+     * Get a single deployment from the deployment history of a site.
      *
      * @param  int  $serverId
      * @param  int  $siteId

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -317,6 +317,44 @@ trait ManagesSites
     }
 
     /**
+     * Get the deployments history of the site.
+     *
+     * @param  int  $serverId
+     * @param  int  $siteId
+     * @return string
+     */
+    public function deploymentHistory($serverId, $siteId)
+    {
+        return $this->get("/api/v1/servers/$serverId/sites/$siteId/deployment-history");
+    }
+
+    /**
+     * Get a single deployment from deployment history of the site.
+     *
+     * @param  int  $serverId
+     * @param  int  $siteId
+     * @param  int  $deploymentId
+     * @return string
+     */
+    public function deploymentHistoryDeployment($serverId, $siteId, $deploymentId)
+    {
+        return $this->get("/api/v1/servers/$serverId/sites/$siteId/deployment-history/$deploymentId");
+    }
+    
+    /**
+     * Get the output for a deployment of the site.
+     *
+     * @param  int  $serverId
+     * @param  int  $siteId
+     * @param  int  $deploymentId
+     * @return string
+     */
+    public function deploymentHistoryOutput($serverId, $siteId, $deploymentId)
+    {
+        return $this->get("/api/v1/servers/$serverId/sites/$siteId/deployment-history/$deploymentId/output");
+    }
+
+    /**
      * Enable Hipchat Notifications for the given site.
      *
      * @param  int  $serverId

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -337,7 +337,7 @@ class Site extends Resource
     }
 
     /**
-     * Get the deployments history of the site.
+     * Get a single deployment from the deployment history of a site.
      *
      * @param  int  $deploymentId
      * @return string

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -327,6 +327,38 @@ class Site extends Resource
     }
 
     /**
+     * Get the deployments history of the site.
+     *
+     * @return string
+     */
+    public function getDeploymentHistory()
+    {
+        return $this->forge->deploymentHistory($this->serverId, $this->id);
+    }
+    
+    /**
+     * Get the deployments history of the site.
+     *
+     * @param int $deploymentId
+     * @return string
+     */
+    public function getDeploymentHistoryDeployment($deploymentId)
+    {
+        return $this->forge->deploymentHistoryDeployment($this->serverId, $this->id, $deploymentId);
+    }
+
+    /**
+     * Get the output for a deployment of the site.
+     *
+     * @param  int  $deploymentId
+     * @return string
+     */
+    public function getDeploymentHistoryOutput($deploymentId)
+    {
+        return $this->forge->deploymentHistoryOutput($this->serverId, $this->id, $deploymentId);
+    }
+
+    /**
      * Enable Hipchat Notifications for the given site.
      *
      * @param  array  $data

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -335,11 +335,11 @@ class Site extends Resource
     {
         return $this->forge->deploymentHistory($this->serverId, $this->id);
     }
-    
+
     /**
      * Get the deployments history of the site.
      *
-     * @param int $deploymentId
+     * @param  int  $deploymentId
      * @return string
      */
     public function getDeploymentHistoryDeployment($deploymentId)


### PR DESCRIPTION
The `ManagesSite` action and the `Site` resource got new methods to get site deployment history from forge. Used the Forge API endpoints https://forge.laravel.com/api-documentation#deployment-history.

## Site Resource

- getDeploymentHistory() ;
- getDeploymentHistoryDeployment($deploymentId);
- getDeploymentHistoryOutput($deploymentId);

## ManagesSites Action

- deploymentHistory($serverId, $siteId);
- deploymentHistoryDeployment($serverId, $siteId, $deploymentId)
- deploymentHistoryOutput($serverId, $siteId, $deploymentId)

This lets a user get the deployment history, a single history deployment by id and a specific deployment output.

Method naming might not be perfect. 

Thanks