### PR TITLE
Use JSON payloads for requests

### DIFF
--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -69,7 +69,7 @@ trait MakesHttpRequests
     protected function request($verb, $uri, array $payload = [])
     {
         $response = $this->guzzle->request($verb, $uri,
-            empty($payload) ? [] : ['form_params' => $payload]
+            empty($payload) ? [] : ['json' => $payload]
         );
 
         $statusCode = $response->getStatusCode();


### PR DESCRIPTION
The `form_params` value here appears to no longer work for a number of operation.

Changing `form_params` to `json` ensures that the payload is an actual JSON payload and that it will be parsed properly.

Without this change, I was unable to run recipes via the SDK. I continued to receive 422 Status replies saying that the server IDs were invalid. After this change, I was able to successfully run recipes on servers.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
