### PR TITLE
[3.x] Fixes updating site aliases

### DIFF
--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -69,7 +69,7 @@ trait ManagesSites
     public function updateSite($serverId, $siteId, array $data)
     {
         return new Site(
-            $this->put("servers/$serverId/sites/$siteId", $data)['site']
+            $this->request('PUT', "servers/$serverId/sites/$siteId", ['json' => $data])['site']
             + ['server_id' => $serverId], $this
         );
     }

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -68,9 +68,11 @@ trait MakesHttpRequests
      */
     protected function request($verb, $uri, array $payload = [])
     {
-        $payload = isset($payload['json'])
-            ? ['json' => $payload['json']]
-            : ['form_params' => $payload];
+        if (isset($payload['json'])) {
+            $payload = ['json' => $payload['json']];
+        } else {
+            $payload = empty($payload) ? [] : ['form_params' => $payload];
+        }
 
         $response = $this->guzzle->request($verb, $uri, $payload);
 

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -68,9 +68,11 @@ trait MakesHttpRequests
      */
     protected function request($verb, $uri, array $payload = [])
     {
-        $response = $this->guzzle->request($verb, $uri,
-            empty($payload) ? [] : ['form_params' => $payload]
-        );
+        $payload = isset($payload['json'])
+            ? ['json' => $payload['json']]
+            : ['form_params' => $payload];
+
+        $response = $this->guzzle->request($verb, $uri, $payload);
 
         $statusCode = $response->getStatusCode();
 

--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -29,6 +29,21 @@ class ForgeSDKTest extends TestCase
         $this->assertCount(1, $forge->recipes());
     }
 
+    public function test_update_site()
+    {
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $http->shouldReceive('request')->once()->with('PUT', 'servers/123/sites/456', [
+            'json' => ['aliases' => ['foo.com']],
+        ])->andReturn(
+            new Response(200, [], '{"site": {"aliases": ["foo.com"]}}')
+        );
+
+        $this->assertSame(['foo.com'], $forge->updateSite('123', '456', [
+            'aliases' => ['foo.com'],
+        ])->aliases);
+    }
+
     public function test_handling_validation_errors()
     {
         $forge = new Forge('123', $http = Mockery::mock(Client::class));


### PR DESCRIPTION
This pull request fixes updating site aliases on Forge SDK, where using an empty list of aliases `['aliases' => []]` as simply being not sent by guzzle.

```
// Before:
// PUT [...] aliases not updated OK
// PUT ['aliases' => []] aliases not updated KO <--- issue here...
// PUT ['aliases' => ['foo.com']] aliases updated OK

// After:
// PUT [...] aliases not updated OK
// PUT ['aliases' => []] aliases updated to empty OK <--- fixed now...
// PUT ['aliases' => ['foo.com']] aliases updated OK
```

At this time, because we are not sure of the ramifications of changing `form_params` by `json` globally - on the entire SDK - so we decided to apply it on this method (`updateSite`) only for now.