### PR TITLE
[3.x] Added syncDatabases function

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ $forge->database($serverId, $databaseId);
 $forge->createDatabase($serverId, array $data, $wait = true);
 $forge->updateDatabase($serverId, $databaseId, array $data);
 $forge->deleteDatabase($serverId, $databaseId);
+$forge->syncDatabases($serverId);
 
 // Users
 $forge->databaseUsers($serverId);

--- a/src/Actions/ManagesDatabases.php
+++ b/src/Actions/ManagesDatabases.php
@@ -87,7 +87,7 @@ trait ManagesDatabases
     }
 
     /**
-     * Sync the databases
+     * Sync the databases.
      *
      * @param  int  $serverId
      * @return void

--- a/src/Actions/ManagesDatabases.php
+++ b/src/Actions/ManagesDatabases.php
@@ -85,4 +85,15 @@ trait ManagesDatabases
     {
         $this->delete("servers/$serverId/databases/$databaseId");
     }
+
+    /**
+     * Sync the databases
+     *
+     * @param  int  $serverId
+     * @return void
+     */
+    public function syncDatabases($serverId)
+    {
+        $this->post("servers/$serverId/databases/sync");
+    }
 }


### PR DESCRIPTION
A new function was added to the Forge API after I asked support about this. The turnaround on this was super quick. This is my addition to the forge-sdk to support this new endpoint. Not 100% sure if I should implement a $wait mechanism too, like when creating a database. I guess not as there is not a created resource to return. So I feel like it should be on the programmer to add sleep() in their logic if they need it (which is what I'm doing now)
