### PR TITLE
Add updated server provider keys

### DIFF
--- a/src/Resources/ServerProviders.php
+++ b/src/Resources/ServerProviders.php
@@ -9,7 +9,7 @@ class ServerProviders
     const DIGITAL_OCEAN = 'ocean2';
     const HETZNER = 'hetzner';
     const LINODE = 'linode';
-    const LINODE4 = 'linode5';
+    const LINODE4 = 'linode4';
     const VULTR = 'vultr';
     const VULTR2 = 'vultr2';
 }

--- a/src/Resources/ServerProviders.php
+++ b/src/Resources/ServerProviders.php
@@ -9,5 +9,7 @@ class ServerProviders
     const DIGITAL_OCEAN = 'ocean2';
     const HETZNER = 'hetzner';
     const LINODE = 'linode';
+    const LINODE4 = 'linode5';
     const VULTR = 'vultr';
+    const VULTR2 = 'vultr2';
 }


### PR DESCRIPTION
Forge has used `linode4` for a while now, since `linode` is deprecated. We also recently added `vultr2` instead of `vultr` for the v2 of their API.