### PR TITLE
Add `siteLog` method to allow getting site logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ $site->removeWordPress();
 $site->installPhpMyAdmin($data);
 $site->removePhpMyAdmin();
 $site->changePHPVersion($version);
+$site->siteLog();
 ```
 
 ### Site Workers

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -31,7 +31,6 @@ trait ManagesSites
     public function site($serverId, $siteId)
     {
         return new Site(
-            $this->get("servers/$serverId/sites/$siteId")['site'] + ['server_id' => $serverId], $this
         );
     }
 
@@ -70,7 +69,6 @@ trait ManagesSites
     {
         return new Site(
             $this->request('PUT', "servers/$serverId/sites/$siteId", ['json' => $data])['site']
-            + ['server_id' => $serverId], $this
         );
     }
 
@@ -86,7 +84,6 @@ trait ManagesSites
     {
         return new Site(
             $this->put("servers/$serverId/sites/$siteId/aliases", compact('aliases'))['site']
-            + ['server_id' => $serverId], $this
         );
     }
 
@@ -453,5 +450,17 @@ trait ManagesSites
     public function updateNodeBalancingConfiguration($serverId, $siteId, array $data)
     {
         $this->put("servers/$serverId/sites/$siteId/balancing", $data);
+    }
+
+    /**
+     * Get the last deployment log of the site.
+     *
+     * @param  int  $serverId
+     * @param  int  $siteId
+     * @return string
+     */
+    public function siteLog($serverId, $siteId)
+    {
+        return $this->get("servers/$serverId/sites/$siteId/logs");
     }
 }

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -31,6 +31,7 @@ trait ManagesSites
     public function site($serverId, $siteId)
     {
         return new Site(
+            $this->get("servers/$serverId/sites/$siteId")['site'] + ['server_id' => $serverId], $this
         );
     }
 
@@ -69,6 +70,7 @@ trait ManagesSites
     {
         return new Site(
             $this->request('PUT', "servers/$serverId/sites/$siteId", ['json' => $data])['site']
+            + ['server_id' => $serverId], $this
         );
     }
 
@@ -84,6 +86,7 @@ trait ManagesSites
     {
         return new Site(
             $this->put("servers/$serverId/sites/$siteId/aliases", compact('aliases'))['site']
+            + ['server_id' => $serverId], $this
         );
     }
 
@@ -453,7 +456,7 @@ trait ManagesSites
     }
 
     /**
-     * Get the last deployment log of the site.
+     * Get the given site's log.
      *
      * @param  int  $serverId
      * @param  int  $siteId

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -444,7 +444,7 @@ class Site extends Resource
     }
 
     /**
-     * Get the last deployment log of the site.
+     * Get the log for this site.
      *
      * @return string
      */

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -442,4 +442,14 @@ class Site extends Resource
     {
         return $this->transformTags($this->tags, $separator);
     }
+
+    /**
+     * Get the last deployment log of the site.
+     *
+     * @return string
+     */
+    public function siteLog()
+    {
+        return $this->forge->siteLog($this->serverId, $this->id);
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request adds a `siteLog` method to the Forge SDK which will allow developers to get the site's log. I've updated the documentation to mention the added method.

* [This endpoint in the Forge API docs](https://forge.laravel.com/api-documentation#site-log)