### PR TITLE
Ensure timout exception always recieves an array

### DIFF
--- a/src/Exceptions/TimeoutException.php
+++ b/src/Exceptions/TimeoutException.php
@@ -9,17 +9,17 @@ class TimeoutException extends Exception
     /**
      * The output returned from the operation.
      *
-     * @var array|null
+     * @var array
      */
     public $output;
 
     /**
      * Create a new exception instance.
      *
-     * @param  array|null  $output
+     * @param  array  $output
      * @return void
      */
-    public function __construct(array $output = null)
+    public function __construct(array $output)
     {
         parent::__construct('Script timed out while waiting for the process to complete.');
 
@@ -29,7 +29,7 @@ class TimeoutException extends Exception
     /**
      * The output returned from the operation.
      *
-     * @return array|null
+     * @return array
      */
     public function output()
     {

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -141,6 +141,14 @@ trait MakesHttpRequests
             goto beginning;
         }
 
+        if ($output === null || $output === false) {
+            $output = [];
+        }
+
+        if (! is_array($output)) {
+            $output = [$output];
+        }
+
         throw new TimeoutException($output);
     }
 }

--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -92,7 +92,8 @@ class ForgeSDKTest extends TestCase
 
     public function testRetryHandlesFalseResultFromClosure()
     {
-        $requestMaker = new class() {
+        $requestMaker = new class()
+        {
             use MakesHttpRequests;
         };
 
@@ -108,7 +109,8 @@ class ForgeSDKTest extends TestCase
 
     public function testRetryHandlesNullResultFromClosure()
     {
-        $requestMaker = new class() {
+        $requestMaker = new class()
+        {
             use MakesHttpRequests;
         };
 
@@ -124,7 +126,8 @@ class ForgeSDKTest extends TestCase
 
     public function testRetryHandlesFalseyStringResultFromClosure()
     {
-        $requestMaker = new class() {
+        $requestMaker = new class()
+        {
             use MakesHttpRequests;
         };
 
@@ -140,7 +143,8 @@ class ForgeSDKTest extends TestCase
 
     public function testRetryHandlesFalseyNumerResultFromClosure()
     {
-        $requestMaker = new class() {
+        $requestMaker = new class()
+        {
             use MakesHttpRequests;
         };
 
@@ -156,7 +160,8 @@ class ForgeSDKTest extends TestCase
 
     public function testRetryHandlesFalseyArrayResultFromClosure()
     {
-        $requestMaker = new class() {
+        $requestMaker = new class()
+        {
             use MakesHttpRequests;
         };
 

--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -97,7 +97,9 @@ class ForgeSDKTest extends TestCase
         };
 
         try {
-            $requestMaker->retry(0, fn () => false, 0);
+            $requestMaker->retry(0, function () {
+                return false;
+            }, 0);
             $this->fail();
         } catch (TimeoutException $e) {
             $this->assertSame([], $e->output());
@@ -111,7 +113,9 @@ class ForgeSDKTest extends TestCase
         };
 
         try {
-            $requestMaker->retry(0, fn () => null, 0);
+            $requestMaker->retry(0, function () {
+                return null;
+            }, 0);
             $this->fail();
         } catch (TimeoutException $e) {
             $this->assertSame([], $e->output());
@@ -125,7 +129,9 @@ class ForgeSDKTest extends TestCase
         };
 
         try {
-            $requestMaker->retry(0, fn () => '', 0);
+            $requestMaker->retry(0, function () {
+                return '';
+            }, 0);
             $this->fail();
         } catch (TimeoutException $e) {
             $this->assertSame([''], $e->output());
@@ -139,7 +145,9 @@ class ForgeSDKTest extends TestCase
         };
 
         try {
-            $requestMaker->retry(0, fn () => 0, 0);
+            $requestMaker->retry(0, function () {
+                return 0;
+            }, 0);
             $this->fail();
         } catch (TimeoutException $e) {
             $this->assertSame([0], $e->output());
@@ -153,7 +161,9 @@ class ForgeSDKTest extends TestCase
         };
 
         try {
-            $requestMaker->retry(0, fn () => [], 0);
+            $requestMaker->retry(0, function () {
+                return [];
+            }, 0);
             $this->fail();
         } catch (TimeoutException $e) {
             $this->assertSame([], $e->output());


### PR DESCRIPTION
fixes #142

reverts changes made in #111

This PR fixes the potential types received by the `TimeoutException`. 

Currently we don't restrict the value returned by the retry closure, thus anything can be returned. Throughout the project we return `null` and `false` in differing situations. Although type analysis would get this sorted for us, I've opted to just address this by preparing the data before sending the the exception.

Note that this reverts the changes made here in https://github.com/laravel/forge-sdk/issues/109 to deal with the bad data closer to it's point of creation an not pass down further into the system.