### PR TITLE
[3.x] Fix updateServer method

### DIFF
--- a/src/Actions/ManagesServers.php
+++ b/src/Actions/ManagesServers.php
@@ -68,7 +68,9 @@ trait ManagesServers
      */
     public function updateServer($serverId, array $data)
     {
-        return $this->put("servers/$serverId", $data)['server'];
+        $server = $this->put("servers/$serverId", $data)['server'];
+
+        return new Server($server, $this);
     }
 
     /**


### PR DESCRIPTION
The `updateServer` method is now documented returning a Server instance but it actually returns an array - raw result of server property from http response.

Thus, inside `updateServer` method, I create a new Server instance that is similar to createServer method and then return it.
