### PR TITLE
Add Exception for Exceeding Forge API Rate Limit

### DIFF
--- a/src/Exceptions/RateLimitExceededException.php
+++ b/src/Exceptions/RateLimitExceededException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Forge\Exceptions;
+
+use Exception;
+
+class RateLimitExceededException extends Exception
+{
+    /**
+     * The timestamp that the rate limit will be reset
+     *
+     * @var int|null
+     */
+    public $rateLimitResetsAt;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @return void
+     */
+    public function __construct($rateLimitReset)
+    {
+        parent::__construct('Too Many Attempts.');
+
+        $this->rateLimitResetsAt = $rateLimitReset;
+    }
+}

--- a/src/Exceptions/RateLimitExceededException.php
+++ b/src/Exceptions/RateLimitExceededException.php
@@ -16,6 +16,7 @@ class RateLimitExceededException extends Exception
     /**
      * Create a new exception instance.
      *
+     * @param  int|null  $rateLimitReset
      * @return void
      */
     public function __construct($rateLimitReset)

--- a/src/Exceptions/RateLimitExceededException.php
+++ b/src/Exceptions/RateLimitExceededException.php
@@ -7,7 +7,7 @@ use Exception;
 class RateLimitExceededException extends Exception
 {
     /**
-     * The timestamp that the rate limit will be reset
+     * The timestamp that the rate limit will be reset.
      *
      * @var int|null
      */

--- a/src/Exceptions/RateLimitExceededException.php
+++ b/src/Exceptions/RateLimitExceededException.php
@@ -21,7 +21,7 @@ class RateLimitExceededException extends Exception
      */
     public function __construct($rateLimitReset)
     {
-        parent::__construct('Too Many Attempts.');
+        parent::__construct('Too Many Requests.');
 
         $this->rateLimitResetsAt = $rateLimitReset;
     }

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -5,8 +5,8 @@ namespace Laravel\Forge;
 use Exception;
 use Laravel\Forge\Exceptions\FailedActionException;
 use Laravel\Forge\Exceptions\NotFoundException;
-use Laravel\Forge\Exceptions\TimeoutException;
 use Laravel\Forge\Exceptions\RateLimitExceededException;
+use Laravel\Forge\Exceptions\TimeoutException;
 use Laravel\Forge\Exceptions\ValidationException;
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -114,7 +114,7 @@ trait MakesHttpRequests
             throw new FailedActionException((string) $response->getBody());
         }
 
-        if ($response->getStatusCode() == 429) {
+        if ($response->getStatusCode() === 429) {
             throw new RateLimitExceededException(
                 $response->hasHeader('x-ratelimit-reset')
                     ? (int) $response->getHeader('x-ratelimit-reset')[0]

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -6,6 +6,7 @@ use Exception;
 use Laravel\Forge\Exceptions\FailedActionException;
 use Laravel\Forge\Exceptions\NotFoundException;
 use Laravel\Forge\Exceptions\TimeoutException;
+use Laravel\Forge\Exceptions\RateLimitExceededException;
 use Laravel\Forge\Exceptions\ValidationException;
 use Psr\Http\Message\ResponseInterface;
 
@@ -97,6 +98,7 @@ trait MakesHttpRequests
      * @throws \Laravel\Forge\Exceptions\FailedActionException
      * @throws \Laravel\Forge\Exceptions\NotFoundException
      * @throws \Laravel\Forge\Exceptions\ValidationException
+     * @throws \Laravel\Forge\Exceptions\RateLimitExceededException
      */
     protected function handleRequestError(ResponseInterface $response)
     {
@@ -110,6 +112,14 @@ trait MakesHttpRequests
 
         if ($response->getStatusCode() == 400) {
             throw new FailedActionException((string) $response->getBody());
+        }
+
+        if ($response->getStatusCode() == 429) {
+            throw new RateLimitExceededException(
+                $response->hasHeader('x-ratelimit-reset')
+                    ? (int) $response->getHeader('x-ratelimit-reset')[0]
+                    : null
+            );
         }
 
         throw new Exception((string) $response->getBody());

--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -184,7 +184,7 @@ class ForgeSDKTest extends TestCase
 
         $http->shouldReceive('request')->once()->with('GET', 'recipes', [])->andReturn(
             new Response(429, [
-                'x-ratelimit-reset' => $timestamp
+                'x-ratelimit-reset' => $timestamp,
             ], 'Too Many Attempts.')
         );
 


### PR DESCRIPTION
Hello,

This PR introduces an additional Exception for Exceeding the Forge API Rate Limit.

The Exception handles the `x-ratelimit-reset` header so users can handle being able to retry after the limit has been reset.