### PR TITLE
Add PHP 8.2 to installable service constants

### DIFF
--- a/src/Resources/InstallableServices.php
+++ b/src/Resources/InstallableServices.php
@@ -12,6 +12,7 @@ class InstallableServices
     const PHP_74 = 'php74';
     const PHP_80 = 'php80';
     const PHP_81 = 'php81';
+    const PHP_82 = 'php82';
 
     const MYSQL = 'mysql';
     const MYSQL_8 = 'mysql8';


### PR DESCRIPTION
This adds the PHP 8.2 constant to the installable services.
