### PR TITLE
Preserve Initial Server Credentials During Creation Wait

### DIFF
--- a/src/Actions/ManagesServers.php
+++ b/src/Actions/ManagesServers.php
@@ -44,9 +44,9 @@ trait ManagesServers
         $response = $this->post('servers', $data);
 
         $server = $response['server'];
-        $initialSudoPassword = @$response['sudo_password'];
-		$initialDatabasePassword = @$response['database_password'];
-		$initialProvisionCommand = @$response['provision_command'];
+        $initialSudoPassword = $response['sudo_password'] ?? null;
+		$initialDatabasePassword = $response['database_password'] ?? null;
+		$initialProvisionCommand = $response['provision_command'] ?? null;
         
         $server['sudo_password'] = $initialSudoPassword;
         $server['database_password'] = $initialDatabasePassword;

--- a/src/Actions/ManagesServers.php
+++ b/src/Actions/ManagesServers.php
@@ -44,14 +44,21 @@ trait ManagesServers
         $response = $this->post('servers', $data);
 
         $server = $response['server'];
-        $server['sudo_password'] = @$response['sudo_password'];
-        $server['database_password'] = @$response['database_password'];
-        $server['provision_command'] = @$response['provision_command'];
+        $initialSudoPassword = @$response['sudo_password'];
+		$initialDatabasePassword = @$response['database_password'];
+		$initialProvisionCommand = @$response['provision_command'];
+        
+        $server['sudo_password'] = $initialSudoPassword;
+        $server['database_password'] = $initialDatabasePassword;
+        $server['provision_command'] = $initialProvisionCommand;
 
         if ($wait) {
-            return $this->retry($timeout, function () use ($server) {
+            return $this->retry($timeout, function () use ($server, $initialSudoPassword, $initialDatabasePassword, $initialProvisionCommand) {
                 $server = $this->server($server['id']);
-
+                $server->sudoPassword = $initialSudoPassword;
+				$server->databasePassword = $initialDatabasePassword;
+				$server->provisionCommand = $initialProvisionCommand;
+                
                 return $server->isReady ? $server : null;
             }, 120);
         }


### PR DESCRIPTION
This commit addresses the issue where server credentials (such as sudo password, database password, and provision command) were lost when waiting for server readiness during creation.

Changes made:
1. Introduced variables (`initialSudoPassword`, `initialDatabasePassword`, `initialProvisionCommand`) to store the initial server credentials right after the server creation request.
2. Modified the retry logic in `createServer` method. Now, after each check for server readiness, these initial credentials are reassigned to the server object. This ensures that essential data like `sudo_password` is preserved and available in the final server object, even after multiple readiness checks.
3. Adjusted the server object properties to accommodate these changes, providing a consistent server object structure regardless of whether the wait option is used or not.

This enhancement ensures that all critical server information is retained throughout the server creation process, particularly when the API client opts to wait for server readiness.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
