### PR TITLE
Use Laravel Pint for consistent coding standards

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,10 @@
+name: fix code styling
+
+on:
+  push:
+    branches:
+      - 3.x
+
+jobs:
+  lint:
+    uses: laravel/.github/.github/workflows/coding-standards.yml@main


### PR DESCRIPTION
StyleCI is disabled and we'll now use Pint to keep all Forge code consistently styled.