### PR TITLE
[3.x] Add directory property to Daemon resource

### DIFF
--- a/src/Resources/Daemon.php
+++ b/src/Resources/Daemon.php
@@ -40,6 +40,13 @@ class Daemon extends Resource
     public $status;
 
     /**
+     * The directory where the command is executed.
+     *
+     * @var string
+     */
+    public $directory;
+
+    /**
      * The date/time the daemon was created.
      *
      * @var string


### PR DESCRIPTION
I'm writing a script for my forge deployment automation and I need the directory of the daemon. Should be safe to add since it's part of the API response.