### PR TITLE
Set a User-Agent string

### DIFF
--- a/src/Forge.php
+++ b/src/Forge.php
@@ -99,7 +99,7 @@ class Forge
                 'Authorization' => 'Bearer '.$this->apiKey,
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
-                'User-Agent' => 'Laravel Forge PHP/1.0',
+                'User-Agent' => 'Laravel Forge PHP/3.0',
             ],
         ]);
 

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -99,6 +99,7 @@ class Forge
                 'Authorization' => 'Bearer '.$this->apiKey,
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
+                'User-Agent' => 'Laravel Forge PHP/1.0',
             ],
         ]);
 


### PR DESCRIPTION
To help us identify usage of the Forge SDK, we'll set a User-Agent header on Guzzle.