### PR TITLE
Add deleteSiteLog method to delete the site's log

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ $site->installPhpMyAdmin($data);
 $site->removePhpMyAdmin();
 $site->changePHPVersion($version);
 $site->siteLog();
+$site->deleteSiteLog();
 ```
 
 ### Site Workers

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -485,4 +485,16 @@ trait ManagesSites
     {
         return $this->get("servers/$serverId/sites/$siteId/logs");
     }
+
+    /**
+     * Remove the given site's log when the log formatting is single.
+     *
+     * @param  int  $serverId
+     * @param  int  $siteId
+     * @return void
+     */
+    public function deleteSiteLog($serverId, $siteId)
+    {
+        return $this->delete("servers/$serverId/sites/$siteId/logs");
+    }
 }

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -475,4 +475,14 @@ class Site extends Resource
     {
         return $this->forge->siteLog($this->serverId, $this->id);
     }
+
+    /**
+     * Remove the log for this site.
+     *
+     * @return void
+     */
+    public function deleteSiteLog()
+    {
+        return $this->forge->deleteSiteLog($this->serverId, $this->id);
+    }
 }


### PR DESCRIPTION
This pull request adds a deleteSiteLog method to the Forge SDK which will allow developers to delete the site's log.

While this works fine for single log configuration. 
I wonder what can be done if there are multiple log files present. 

Maybe just like forge pulls in the 500 lines from the last updated file, deleting logs from the last updated file or log file for current day can be done for daily log configuration.

I wanted to create a feature request issue and I was redirected to create a pull request. 
And here I am with my feature-request pull-request. 

Thank you for your time and consideration.