### PR TITLE
add method for "Get Server Event Output" API route

### DIFF
--- a/src/Actions/ManagesServers.php
+++ b/src/Actions/ManagesServers.php
@@ -328,4 +328,16 @@ trait ManagesServers
             Event::class
         );
     }
+
+    /**
+     * Get event details
+     *
+     * @param  string  $serverId
+     * @param  string  $eventId
+     * @return \Laravel\Forge\Resources\Event
+     */
+    public function event($serverId, $eventId)
+    {
+        return new Event($this->get("servers/$serverId/events/$eventId"), $this);
+    }
 }


### PR DESCRIPTION
This PR adds a method into the ManageServers trait for getting event output for a specific event. The endpoint exists in the API, but was not represented in this SDK. This will not break any existing features since it only calls the necessary endpoint and returns the Event Resource
