### PR TITLE
Throw separate "Forbidden" (403) exceptions

### DIFF
--- a/src/Exceptions/ForbiddenException.php
+++ b/src/Exceptions/ForbiddenException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Forge\Exceptions;
+
+use Exception;
+
+class ForbiddenException extends Exception
+{
+    //
+}

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -4,6 +4,7 @@ namespace Laravel\Forge;
 
 use Exception;
 use Laravel\Forge\Exceptions\FailedActionException;
+use Laravel\Forge\Exceptions\ForbiddenException;
 use Laravel\Forge\Exceptions\NotFoundException;
 use Laravel\Forge\Exceptions\RateLimitExceededException;
 use Laravel\Forge\Exceptions\TimeoutException;
@@ -91,6 +92,7 @@ trait MakesHttpRequests
      *
      * @throws \Exception
      * @throws \Laravel\Forge\Exceptions\FailedActionException
+     * @throws \Laravel\Forge\Exceptions\ForbiddenException
      * @throws \Laravel\Forge\Exceptions\NotFoundException
      * @throws \Laravel\Forge\Exceptions\ValidationException
      * @throws \Laravel\Forge\Exceptions\RateLimitExceededException
@@ -99,6 +101,10 @@ trait MakesHttpRequests
     {
         if ($response->getStatusCode() == 422) {
             throw new ValidationException(json_decode((string) $response->getBody(), true));
+        }
+
+        if ($response->getStatusCode() === 403) {
+            throw new ForbiddenException((string) $response->getBody());
         }
 
         if ($response->getStatusCode() == 404) {

--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -5,6 +5,7 @@ namespace Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Laravel\Forge\Exceptions\FailedActionException;
+use Laravel\Forge\Exceptions\ForbiddenException;
 use Laravel\Forge\Exceptions\NotFoundException;
 use Laravel\Forge\Exceptions\RateLimitExceededException;
 use Laravel\Forge\Exceptions\TimeoutException;
@@ -71,6 +72,19 @@ class ForgeSDKTest extends TestCase
 
         $http->shouldReceive('request')->once()->with('GET', 'recipes', [])->andReturn(
             new Response(404)
+        );
+
+        $forge->recipes();
+    }
+
+    public function test_handling_forbidden_requests(): void
+    {
+        $this->expectException(ForbiddenException::class);
+
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $http->shouldReceive('request')->once()->with('GET', 'recipes', [])->andReturn(
+            new Response(403)
         );
 
         $forge->recipes();


### PR DESCRIPTION
Currently, these are cast to generic \Exception instances, which are difficult for users catch and/or identify.