### PR TITLE
Adding PHP 8.4 InstallableServices

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.yml
@@ -22,7 +22,7 @@ body:
     attributes:
       label: PHP Version
       description: Provide the PHP version that you are using.
-      placeholder: 8.1.4
+      placeholder: 8.4.2
     validations:
       required: true
   - type: input
@@ -44,4 +44,4 @@ body:
       description: Provide detailed steps to reproduce your issue. If necessary, please provide a GitHub repository to demonstrate your issue using `laravel new bug-report --github="--public"`.
     validations:
       required: true
-      
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, '8.0', 8.1, 8.2, 8.3]
+        php: [7.2, 7.3, 7.4, '8.0', 8.1, 8.2, 8.3, 8.4]
 
     name: PHP ${{ matrix.php }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $server = $forge->createServer([
     "size"=> "01",
     "database"=> "test123",
     "database_type" => InstallableServices::POSTGRES,
-    "php_version"=> InstallableServices::PHP_71,
+    "php_version"=> InstallableServices::PHP_84,
     "region"=> "ams2"
 ]);
 ```

--- a/src/Resources/InstallableServices.php
+++ b/src/Resources/InstallableServices.php
@@ -24,6 +24,8 @@ class InstallableServices
 
     const PHP_83 = 'php83';
 
+    const PHP_84 = 'php84';
+
     const MYSQL = 'mysql';
 
     const MYSQL_8 = 'mysql8';


### PR DESCRIPTION
- Adding PHP 8.4 to InstallableServices
- Adding .idea to `.gitignore`
- Updating Readme to use PHP 8.4 instead of 7.1
- Adding PHP 8.4 to GitHub tests workflow
- Updating bug report template placeholder to use PHP 8.4