### PR TITLE
Added setDeploymentFailureEmails support to the sites class

### DIFF
--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -402,6 +402,18 @@ trait ManagesSites
     }
 
     /**
+     * Set the deployment failure emails for the given site.
+     *
+     * @param  int  $serverId
+     * @param  int  $siteId
+     * @return void
+     */
+    public function setDeploymentFailureEmails($serverId, $siteId, array $data)
+    {
+        $this->post("servers/$serverId/sites/$siteId/deployment-failure-emails", $data);
+    }
+
+    /**
      * Install a new WordPress project.
      *
      * @param  int  $serverId

--- a/src/Facades/Forge.php
+++ b/src/Facades/Forge.php
@@ -132,6 +132,7 @@ use Laravel\Forge\ForgeManager;
  * @method static string deploymentHistoryOutput(int $serverId, int $siteId, int $deploymentId)
  * @method static void enableHipchatNotifications(int $serverId, int $siteId, array $data)
  * @method static void disableHipchatNotifications(int $serverId, int $siteId)
+ * @method static void setDeploymentFailureEmails(int $serverId, int $siteId, array $data)
  * @method static void installWordPress(int $serverId, int $siteId, array $data)
  * @method static void removeWordPress(int $serverId, int $siteId)
  * @method static void installPhpMyAdmin(int $serverId, int $siteId, array $data)

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -405,6 +405,16 @@ class Site extends Resource
     }
 
     /**
+     * Set the deployment failure emails for a site.
+     *
+     * @return void
+     */
+    public function setDeploymentFailureEmails(array $data)
+    {
+        $this->forge->setDeploymentFailureEmails($this->serverId, $this->id, $data);
+    }
+
+    /**
      * Install a new WordPress project.
      *
      * @return void


### PR DESCRIPTION
Added `setDeploymentFailureEmails` to support [Deployment Failure Emails](https://forge.laravel.com/api-documentation#deployment-failure-emails) that was in the docs but not in the SDK yet. Also related to https://github.com/laravel/forge-sdk/issues/178
