### PR TITLE
Fix incorrect and inconsistent docstrings across resources

### DIFF
--- a/src/Actions/ManagesSiteCommands.php
+++ b/src/Actions/ManagesSiteCommands.php
@@ -23,7 +23,7 @@ trait ManagesSiteCommands
      *
      * @param  int  $serverId
      * @param  int  $siteId
-     * @return \Laravel\Forge\Resources\SiteCommand
+     * @return \Laravel\Forge\Resources\SiteCommand[]
      */
     public function listCommandHistory($serverId, $siteId)
     {

--- a/src/Resources/BackupConfiguration.php
+++ b/src/Resources/BackupConfiguration.php
@@ -65,7 +65,7 @@ class BackupConfiguration extends Resource
     public $databases;
 
     /**
-     * The databases for this backup.
+     * The backups for this configuration.
      *
      * @var \Laravel\Forge\Resources\Backup[]
      */

--- a/src/Resources/SecurityRule.php
+++ b/src/Resources/SecurityRule.php
@@ -40,7 +40,7 @@ class SecurityRule extends Resource
     public $path;
 
     /**
-     * The credentials of the redirect rule.
+     * The credentials of the security rule.
      *
      * @var string
      */
@@ -54,7 +54,7 @@ class SecurityRule extends Resource
     public $createdAt;
 
     /**
-     * Delete the given redirect rule.
+     * Delete the given security rule.
      *
      * @return void
      */

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -201,7 +201,7 @@ class Site extends Resource
     public $phpVersion;
 
     /**
-     * The aliases of the site.
+     * The tags of the site.
      *
      * @var array
      */

--- a/src/Resources/SiteCommand.php
+++ b/src/Resources/SiteCommand.php
@@ -61,7 +61,7 @@ class SiteCommand extends Resource
     public $createdAt;
 
     /**
-     * The The updated_at time for the command.
+     * The updated_at time for the command.
      *
      * @var string
      */


### PR DESCRIPTION
Fixes #208

## Summary

Corrects copy-paste errors and incorrect docstrings across 5 files:

- **SecurityRule.php**: `$credentials` and `delete()` docstrings incorrectly say "redirect rule" — fixed to "security rule"
- **SiteCommand.php**: `$updatedAt` docstring has duplicate "The The" — removed duplicate
- **Site.php**: `$tags` property docstring says "aliases" — fixed to "tags"
- **BackupConfiguration.php**: `$backups` property docstring says "databases" — fixed to "backups"
- **ManagesSiteCommands.php**: `listCommandHistory()` return type incorrectly documented as `SiteCommand` — fixed to `SiteCommand[]` since the method returns an array

## Test plan

- [x] Docstring-only changes — no runtime behaviour affected
- [x] `listCommandHistory()` return type fix improves IDE autocompletion accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)