### PR TITLE
Fix createDatabase wait with string IDs

### DIFF
--- a/src/Actions/ManagesDatabases.php
+++ b/src/Actions/ManagesDatabases.php
@@ -46,7 +46,7 @@ trait ManagesDatabases
 
         if ($wait) {
             return $this->retry($this->getTimeout(), function () use ($organizationSlug, $serverId, $database) {
-                $db = $this->database($organizationSlug, $serverId, $database['id']);
+                $db = $this->database($organizationSlug, $serverId, (int) $database['id']);
 
                 return isset($db->status) && $db->status === 'installed' ? $db : null;
             });

--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -360,6 +360,25 @@ class ForgeSDKTest extends TestCase
         $this->assertSame(1, $database->id);
     }
 
+    public function test_creating_database_waits_with_string_id()
+    {
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $http->shouldReceive('request')->once()->with('POST', 'orgs/org-123/servers/1/database/schemas', [
+            'json' => ['name' => 'my_database'],
+        ])->andReturn(
+            new Response(200, [], '{"data": {"id": "1", "name": "my_database", "status": "installing"}}')
+        );
+
+        $http->shouldReceive('request')->once()->with('GET', 'orgs/org-123/servers/1/database/schemas/1', [])->andReturn(
+            new Response(200, [], '{"data": {"id": 1, "name": "my_database", "status": "installed"}}')
+        );
+
+        $database = $forge->createDatabase('org-123', 1, ['name' => 'my_database']);
+        $this->assertSame(1, $database->id);
+        $this->assertSame('installed', $database->status);
+    }
+
     public function test_deleting_database()
     {
         $forge = new Forge('123', $http = Mockery::mock(Client::class));


### PR DESCRIPTION
## Summary
- cast the created database id before passing it into `database()` during wait polling
- add a regression test for create responses that return the database id as a string

Fixes #217.

## Tests
- `git diff --check`

I could not run PHPUnit locally because this machine does not have PHP/Composer installed and the Docker daemon is not running.

AI assistance was used under my direction.