### PR TITLE
fix(logs): use v1 endpoint for serverLog() to resolve persistent 404

### DIFF
--- a/src/Actions/ManagesLogs.php
+++ b/src/Actions/ManagesLogs.php
@@ -11,9 +11,9 @@ trait ManagesLogs
      */
     public function serverLog(string $organizationSlug, int $serverId, string $logKey): string
     {
-        $response = $this->get("orgs/{$organizationSlug}/servers/{$serverId}/logs/{$logKey}");
+        $response = $this->get("v1/servers/{$serverId}/logs", ['file' => $logKey]);
 
-        return $response['data']['attributes']['content'] ?? '';
+        return $response['content'] ?? '';
     }
 
     /**

--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -2607,8 +2607,8 @@ class ForgeSDKTest extends TestCase
     {
         $forge = new Forge('123', $http = Mockery::mock(Client::class));
 
-        $http->shouldReceive('request')->once()->with('GET', 'orgs/org-123/servers/1/logs/nginx-error', [])->andReturn(
-            new Response(200, [], '{"data": {"type": "server-logs", "id": "1", "attributes": {"content": "2025/11/18 10:00:00 [error] 1234#1234: *1 connect() failed (111: Connection refused)\n2025/11/18 10:01:00 [warn] 1234#1234: *2 upstream server temporarily disabled\n2025/11/18 10:02:00 [error] 1234#1234: *3 open() \\"/var/www/html/favicon.ico\\" failed (2: No such file or directory)"}}}')
+        $http->shouldReceive('request')->once()->with('GET', 'v1/servers/1/logs', ['query' => ['file' => 'nginx-error']])->andReturn(
+            new Response(200, [], '{"path": "/var/log/nginx/error.log", "content": "2025/11/18 10:00:00 [error] 1234#1234: *1 connect() failed (111: Connection refused)\n2025/11/18 10:01:00 [warn] 1234#1234: *2 upstream server temporarily disabled\n2025/11/18 10:02:00 [error] 1234#1234: *3 open() \\"/var/www/html/favicon.ico\\" failed (2: No such file or directory)"}')
         );
 
         $log = $forge->serverLog('org-123', 1, 'nginx-error');


### PR DESCRIPTION
`Forge::serverLog()` always throws `NotFoundException` because it calls the org-scoped path `GET orgs/{org}/servers/{id}/logs/{key}`, which returns 404 for every server — verified across both old and newly-provisioned servers, for all log keys.

The endpoint that actually works is the v1 path documented under [Server Logs](https://forge.laravel.com/api-documentation#server-logs):

```
GET /api/v1/servers/{serverId}/logs?file={logKey}
```

This response returns a flat `{"path": "...", "content": "..."}` structure rather than the JSON:API envelope the current code tries to unpack.

**Changes:**
- `src/Actions/ManagesLogs.php` — switch `serverLog()` to `v1/servers/{id}/logs` with `file` as a query param; read `content` from the top-level response. `$organizationSlug` is kept in the signature for backward compatibility; `deleteServerLog()` is untouched (out of scope).
- `tests/ForgeSDKTest.php` — update the mock expectation and response fixture to match the v1 path and flat response shape.

**Why the v1 path, not the org-scoped one?** The org-scoped route is listed in the OpenAPI spec but consistently returns 404 in production. The v1 `?file=` endpoint returns HTTP 200 with the expected `content` field and is the path the official API docs describe.

Closes #220