### PR TITLE
Add LogKey enum for server log retrieval

### DIFF
--- a/src/Actions/ManagesLogs.php
+++ b/src/Actions/ManagesLogs.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace Laravel\Forge\Actions;
 
+use Laravel\Forge\Enums\LogKey;
+
 trait ManagesLogs
 {
     /**
      * Get server log content.
      */
-    public function serverLog(string $organizationSlug, int $serverId, string $logKey): string
+    public function serverLog(string $organizationSlug, int $serverId, LogKey|string $logKey): string
     {
-        $response = $this->get("orgs/{$organizationSlug}/servers/{$serverId}/logs/{$logKey}");
+        $key = $logKey instanceof LogKey ? $logKey->value : $logKey;
+
+        $response = $this->get("orgs/{$organizationSlug}/servers/{$serverId}/logs/{$key}");
 
         return $response['data']['attributes']['content'] ?? '';
     }
@@ -19,8 +23,10 @@ trait ManagesLogs
     /**
      * Delete server log content.
      */
-    public function deleteServerLog(string $organizationSlug, int $serverId, string $logKey): void
+    public function deleteServerLog(string $organizationSlug, int $serverId, LogKey|string $logKey): void
     {
-        $this->delete("orgs/{$organizationSlug}/servers/{$serverId}/logs/{$logKey}");
+        $key = $logKey instanceof LogKey ? $logKey->value : $logKey;
+
+        $this->delete("orgs/{$organizationSlug}/servers/{$serverId}/logs/{$key}");
     }
 }

--- a/src/Enums/LogKey.php
+++ b/src/Enums/LogKey.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Forge\Enums;
+
+enum LogKey: string
+{
+    case NginxAccess = 'nginx-access';
+    case NginxError = 'nginx-error';
+    case Redis = 'redis-server';
+    case Meilisearch = 'meilisearch';
+    case UnattendedUpgrades = 'unattended-upgrades';
+    case Ssh = 'ssh';
+
+    case Php5 = 'php-5';
+    case Php56 = 'php-5.6';
+    case Php70 = 'php-7.0';
+    case Php71 = 'php-7.1';
+    case Php72 = 'php-7.2';
+    case Php73 = 'php-7.3';
+    case Php74 = 'php-7.4';
+    case Php80 = 'php-8.0';
+    case Php81 = 'php-8.1';
+    case Php82 = 'php-8.2';
+    case Php83 = 'php-8.3';
+    case Php84 = 'php-8.4';
+    case Php85 = 'php-8.5';
+
+    case Mysql = 'database-mysql';
+    case MariaDb = 'database-mariadb';
+    case Postgresql = 'database-postgresql';
+}

--- a/tests/ForgeSDKTest.php
+++ b/tests/ForgeSDKTest.php
@@ -45,6 +45,7 @@ use Laravel\Forge\Resources\TeamInvitation;
 use Laravel\Forge\Resources\TeamMember;
 use Laravel\Forge\Resources\User;
 use Laravel\Forge\Resources\Webhook;
+use Laravel\Forge\Enums\LogKey;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -2643,6 +2644,30 @@ class ForgeSDKTest extends TestCase
         );
 
         $forge->deleteServerLog('org-123', 1, 'nginx-error');
+        $this->assertTrue(true); // Assertion to avoid risky test warning
+    }
+
+    public function test_getting_server_log_with_enum()
+    {
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $http->shouldReceive('request')->once()->with('GET', 'orgs/org-123/servers/1/logs/nginx-error', [])->andReturn(
+            new Response(200, [], '{"data": {"type": "server-logs", "id": "1", "attributes": {"content": "error log content"}}}')
+        );
+
+        $log = $forge->serverLog('org-123', 1, LogKey::NginxError);
+        $this->assertStringContainsString('error log content', $log);
+    }
+
+    public function test_deleting_server_log_with_enum()
+    {
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $http->shouldReceive('request')->once()->with('DELETE', 'orgs/org-123/servers/1/logs/nginx-error', [])->andReturn(
+            new Response(204)
+        );
+
+        $forge->deleteServerLog('org-123', 1, LogKey::NginxError);
         $this->assertTrue(true); // Assertion to avoid risky test warning
     }
 


### PR DESCRIPTION
## Summary

- Adds `LogKey` backed string enum covering all static log keys (nginx, redis, meilisearch, SSH, PHP 5–8.5, MySQL, MariaDB, PostgreSQL)
- Updates `serverLog()` and `deleteServerLog()` in `ManagesLogs` to accept `LogKey|string`, so callers can pass an enum case or a raw string (e.g. for dynamic keys like `background-process-{id}`)

Closes #220