### PR TITLE
Expose JSON:API includes so callers can hydrate tags and other relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/laravel/forge-sdk/compare/v4.1.0...4.x)
 
+### What's Changed
+
+* Support `include` query parameter on `server()` and `organizationSite()`, and expose the JSON:API `included` document via a new `included()` helper on resources (fixes [#228](https://github.com/laravel/forge-sdk/issues/228))
+
 ## [v4.1.0](https://github.com/laravel/forge-sdk/compare/v4.0.2...v4.1.0) - 2026-06-26
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ $page = $forge->servers($organizationSlug)->toArray();
 
 Each resource is represented by an instance like `Laravel\Forge\Resources\Server`, with public properties such as `$name`, `$id`, `$size`, `$region`, and others.
 
+#### Including Related Resources
+
+Some resources expose relationships (such as tags) that aren't returned by default. Pass an `include` query parameter to hydrate them, then resolve the pointers via the `included()` helper on the resource:
+
+```php
+$server = $forge->server($organizationSlug, $serverId, ['include' => 'tags']);
+
+foreach ($server->included('tags') as $tag) {
+    echo $tag['attributes']['name'];
+}
+```
+
+The same pattern works for site fetches and collection methods:
+
+```php
+$site = $forge->organizationSite($organizationSlug, $siteId, ['include' => 'tags']);
+$servers = $forge->servers($organizationSlug, ['include' => 'tags']);
+```
+
+Multiple relationships can be requested by comma-separating them (e.g. `'include' => 'tags,latestDeployment'`). The raw `included` document is also available on each resource as `$server->included`.
+
 #### Waiting for Async Operations
 
 Some methods wait for the action to complete on Forge's end by periodically checking the resource status:

--- a/src/Actions/ManagesServers.php
+++ b/src/Actions/ManagesServers.php
@@ -27,12 +27,15 @@ trait ManagesServers
     /**
      * Get a server instance.
      */
-    public function server(string $organizationSlug, int $serverId): Server
+    public function server(string $organizationSlug, int $serverId, array $query = []): Server
     {
+        $response = $this->get("orgs/{$organizationSlug}/servers/{$serverId}", $query);
+
         return $this->newResource(
             Server::class,
-            $this->get("orgs/{$organizationSlug}/servers/{$serverId}")['data'] ?? [],
+            $response['data'] ?? [],
             $organizationSlug,
+            included: $response['included'] ?? [],
         );
     }
 

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -43,12 +43,15 @@ trait ManagesSites
     /**
      * Get a site instance.
      */
-    public function organizationSite(string $organizationSlug, int $siteId): Site
+    public function organizationSite(string $organizationSlug, int $siteId, array $query = []): Site
     {
+        $response = $this->get("orgs/{$organizationSlug}/sites/{$siteId}", $query);
+
         return $this->newResource(
             Site::class,
-            $this->get("orgs/{$organizationSlug}/sites/{$siteId}")['data'] ?? [],
+            $response['data'] ?? [],
             $organizationSlug,
+            included: $response['included'] ?? [],
         );
     }
 

--- a/src/CursorPaginator.php
+++ b/src/CursorPaginator.php
@@ -103,6 +103,7 @@ class CursorPaginator implements IteratorAggregate, Countable, ArrayAccess, Json
 
         $data = $response['data'] ?? [];
         $meta = $response['meta'] ?? [];
+        $included = $response['included'] ?? [];
 
         $items = $this->forge->transformCollection(
             $data,
@@ -111,6 +112,7 @@ class CursorPaginator implements IteratorAggregate, Countable, ArrayAccess, Json
             $this->serverId,
             $this->siteId,
             $this->extra,
+            $included,
         );
 
         return new self(

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -73,6 +73,7 @@ class Forge
         ?int $serverId = null,
         ?int $siteId = null,
         array $extra = [],
+        array $included = [],
     ): array {
         $context = array_filter([
             'organization_slug' => $organizationSlug,
@@ -82,8 +83,8 @@ class Forge
 
         $extraData = $context + $extra;
 
-        return array_map(function ($data) use ($class, $extraData) {
-            return new $class($data + $extraData, $this);
+        return array_map(function ($data) use ($class, $extraData, $included) {
+            return new $class($data + $extraData, $this, $included);
         }, $collection);
     }
 
@@ -107,6 +108,7 @@ class Forge
         ?int $serverId = null,
         ?int $siteId = null,
         array $extra = [],
+        array $included = [],
     ): mixed {
         $context = array_filter([
             'organization_slug' => $organizationSlug,
@@ -114,7 +116,7 @@ class Forge
             'site_id' => $siteId,
         ], fn ($v) => ! is_null($v));
 
-        return new $class($data + $context + $extra, $this);
+        return new $class($data + $context + $extra, $this, $included);
     }
 
     /**
@@ -133,6 +135,7 @@ class Forge
 
         $data = $response['data'] ?? [];
         $meta = $response['meta'] ?? [];
+        $included = $response['included'] ?? [];
 
         $items = $this->transformCollection(
             $data,
@@ -141,6 +144,7 @@ class Forge
             $serverId,
             $siteId,
             $extra,
+            $included,
         );
 
         return new CursorPaginator(

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -9,13 +9,10 @@ use Laravel\Forge\Forge;
 /**
  * Base class for all hydrated Forge API resources.
  *
- * Hydration preserves the JSON:API `relationships` and `links` blocks as raw
- * arrays on the resource (matching their original JSON:API shape) so callers
- * can follow IDs and sub-resource links without re-parsing attributes or making
- * redundant API calls. Note that the top-level `included` document is NOT
- * auto-resolved: the SDK only consumes the `data` envelope from responses, so
- * any references in `relationships` remain as identifier pointers rather than
- * fully-hydrated child resources.
+ * Hydration preserves the JSON:API `relationships`, `links`, and `included`
+ * blocks as raw arrays on the resource. Use `included($name)` to resolve
+ * relationship pointers against the top-level `included` document returned
+ * when the response was fetched with an `include` query parameter.
  */
 class Resource
 {
@@ -35,6 +32,11 @@ class Resource
     public array $links = [];
 
     /**
+     * The raw JSON:API `included` document, preserved as-is.
+     */
+    public array $included = [];
+
+    /**
      * The Forge SDK instance.
      */
     protected ?Forge $forge = null;
@@ -42,22 +44,56 @@ class Resource
     /**
      * Create a new resource instance.
      */
-    public function __construct(array $attributes, ?Forge $forge = null)
+    public function __construct(array $attributes, ?Forge $forge = null, array $included = [])
     {
         $this->attributes = $attributes;
         $this->forge = $forge;
+        $this->included = $included;
 
         $this->fill();
     }
 
     /**
+     * Resolve the given relationship's pointers against the `included` document.
+     */
+    public function included(string $name): array
+    {
+        $pointers = $this->relationships[$name]['data'] ?? null;
+
+        if (! is_array($pointers) || $pointers === []) {
+            return [];
+        }
+
+        $isSingle = isset($pointers['type']);
+        $pointers = $isSingle ? [$pointers] : $pointers;
+
+        $index = [];
+
+        foreach ($this->included as $item) {
+            if (isset($item['type'], $item['id'])) {
+                $index[$item['type'].':'.$item['id']] = $item;
+            }
+        }
+
+        $matches = [];
+
+        foreach ($pointers as $pointer) {
+            if (! isset($pointer['type'], $pointer['id'])) {
+                continue;
+            }
+
+            $key = $pointer['type'].':'.$pointer['id'];
+
+            if (isset($index[$key])) {
+                $matches[] = $index[$key];
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
      * Fill the resource with the array of attributes.
-     *
-     * `relationships` and `links` from a JSON:API payload are assigned to the
-     * matching public properties via the camelCase + `property_exists` loop
-     * below, preserving the raw JSON:API shape. The top-level `included`
-     * document is not consumed (the SDK only sees the `data` envelope), so
-     * relationship references remain unresolved identifier pointers.
      */
     protected function fill(): void
     {

--- a/tests/JsonApiResponseTest.php
+++ b/tests/JsonApiResponseTest.php
@@ -253,6 +253,173 @@ class JsonApiResponseTest extends TestCase
         );
     }
 
+    public function test_server_with_included_tags(): void
+    {
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $jsonApiPayload = json_encode([
+            'data' => [
+                'id' => 42,
+                'type' => 'servers',
+                'attributes' => ['name' => 'production-web'],
+                'relationships' => [
+                    'tags' => [
+                        'data' => [
+                            ['type' => 'tags', 'id' => '1'],
+                            ['type' => 'tags', 'id' => '2'],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => '1',
+                    'type' => 'tags',
+                    'attributes' => ['name' => 'production'],
+                ],
+                [
+                    'id' => '2',
+                    'type' => 'tags',
+                    'attributes' => ['name' => 'web'],
+                ],
+            ],
+        ]);
+
+        $http->shouldReceive('request')
+            ->once()
+            ->with('GET', 'orgs/org-123/servers/42', ['query' => ['include' => 'tags']])
+            ->andReturn(new Response(200, [], $jsonApiPayload));
+
+        $server = $forge->server('org-123', 42, ['include' => 'tags']);
+
+        $this->assertCount(2, $server->included);
+        $this->assertSame('tags', $server->included[0]['type']);
+
+        $tags = $server->included('tags');
+        $this->assertCount(2, $tags);
+        $this->assertSame('production', $tags[0]['attributes']['name']);
+        $this->assertSame('web', $tags[1]['attributes']['name']);
+
+        $this->assertSame([], $server->included('missing'));
+    }
+
+    public function test_site_with_included_tags(): void
+    {
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $jsonApiPayload = json_encode([
+            'data' => [
+                'id' => 7,
+                'type' => 'sites',
+                'attributes' => ['name' => 'example.com'],
+                'relationships' => [
+                    'tags' => [
+                        'data' => [['type' => 'tags', 'id' => '5']],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => '5',
+                    'type' => 'tags',
+                    'attributes' => ['name' => 'staging'],
+                ],
+            ],
+        ]);
+
+        $http->shouldReceive('request')
+            ->once()
+            ->with('GET', 'orgs/org-123/sites/7', ['query' => ['include' => 'tags']])
+            ->andReturn(new Response(200, [], $jsonApiPayload));
+
+        $site = $forge->organizationSite('org-123', 7, ['include' => 'tags']);
+
+        $tags = $site->included('tags');
+        $this->assertCount(1, $tags);
+        $this->assertSame('staging', $tags[0]['attributes']['name']);
+    }
+
+    public function test_site_with_included_single_relationship(): void
+    {
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $jsonApiPayload = json_encode([
+            'data' => [
+                'id' => 7,
+                'type' => 'sites',
+                'attributes' => ['name' => 'example.com'],
+                'relationships' => [
+                    'latestDeployment' => [
+                        'data' => ['type' => 'deployments', 'id' => '99'],
+                    ],
+                    'server' => ['data' => null],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => '99',
+                    'type' => 'deployments',
+                    'attributes' => ['status' => 'finished'],
+                ],
+            ],
+        ]);
+
+        $http->shouldReceive('request')
+            ->once()
+            ->with('GET', 'orgs/org-123/sites/7', ['query' => ['include' => 'latestDeployment']])
+            ->andReturn(new Response(200, [], $jsonApiPayload));
+
+        $site = $forge->organizationSite('org-123', 7, ['include' => 'latestDeployment']);
+
+        $deployments = $site->included('latestDeployment');
+        $this->assertCount(1, $deployments);
+        $this->assertSame('99', $deployments[0]['id']);
+        $this->assertSame('finished', $deployments[0]['attributes']['status']);
+
+        $this->assertSame([], $site->included('server'));
+    }
+
+    public function test_server_collection_propagates_included_document(): void
+    {
+        $forge = new Forge('123', $http = Mockery::mock(Client::class));
+
+        $jsonApiPayload = json_encode([
+            'data' => [
+                [
+                    'id' => 1,
+                    'type' => 'servers',
+                    'attributes' => ['name' => 'Server One'],
+                    'relationships' => [
+                        'tags' => ['data' => [['type' => 'tags', 'id' => '10']]],
+                    ],
+                ],
+                [
+                    'id' => 2,
+                    'type' => 'servers',
+                    'attributes' => ['name' => 'Server Two'],
+                    'relationships' => [
+                        'tags' => ['data' => [['type' => 'tags', 'id' => '11']]],
+                    ],
+                ],
+            ],
+            'included' => [
+                ['id' => '10', 'type' => 'tags', 'attributes' => ['name' => 'alpha']],
+                ['id' => '11', 'type' => 'tags', 'attributes' => ['name' => 'beta']],
+            ],
+        ]);
+
+        $http->shouldReceive('request')
+            ->once()
+            ->with('GET', 'orgs/org-123/servers', ['query' => ['include' => 'tags']])
+            ->andReturn(new Response(200, [], $jsonApiPayload));
+
+        $servers = $forge->servers('org-123', ['include' => 'tags']);
+
+        $this->assertCount(1, $servers[0]->included('tags'));
+        $this->assertSame('alpha', $servers[0]->included('tags')[0]['attributes']['name']);
+        $this->assertSame('beta', $servers[1]->included('tags')[0]['attributes']['name']);
+    }
+
     public function test_server_collection_from_jsonapi_response(): void
     {
         $forge = new Forge('123', $http = Mockery::mock(Client::class));


### PR DESCRIPTION
Fixes #228.

Querying a server or a site through the SDK returned an empty `relationships` block and no way to hydrate related resources such as tags. Two things were missing:

1. `server()` and `organizationSite()` did not accept a `$query` argument, so callers could not pass `?include=tags` (or any other JSON:API include).
2. Even when the API returned an `included` document, the SDK only consumed the top-level `data` envelope and discarded `included`, so relationship identifiers stayed unresolved.

### Changes

- `server(string $organizationSlug, int $serverId, array $query = [])` - new `$query` parameter, forwarded to the API.
- `organizationSite(string $organizationSlug, int $siteId, array $query = [])` - same treatment.
- `Resource` now exposes `public array $included` (populated from the response) and a small `included(string $name): array` helper that resolves `relationships[$name].data` pointers against the shared `included` document. Handles array, single-object, and null relationship shapes.
- `Forge::newResource()`, `Forge::transformCollection()`, `Forge::paginatedCollection()`, and `CursorPaginator::nextPage()` thread the `included` document through to hydrated resources so it is available on collection items too.
- New `included()` helper tests cover: server with tag includes, site with tag includes, site with a single-object relationship (`latestDeployment`) plus a null `server` relationship, and a paginated server collection propagating the shared `included` document.
- README gets a short "Including Related Resources" section under Basic Usage; CHANGELOG has an `[Unreleased]` entry referencing #228.

### Usage

```php
$server = $forge->server($organizationSlug, $serverId, ['include' => 'tags']);

foreach ($server->included('tags') as $tag) {
    echo $tag['attributes']['name'];
}
```

The same pattern works on `organizationSite()` and on collection methods like `servers()` / `serverSites()`.

### Testing

4 new tests added